### PR TITLE
Fix previous version bump.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION ...
-const VERSION = "2.4.2"
+const VERSION = "2.4.3"


### PR DESCRIPTION
The [previous version bump](https://github.com/bitrise-io/codesigndoc/pull/137) was invalid, as version 2.4.2 has already existed, but the version number was not updated.

This PR bumps version number to the correct next version: 2.4.3.
