### PR TITLE
version bump to 2.4.4

### DIFF
--- a/_scripts/install_wrap-xamarin.sh
+++ b/_scripts/install_wrap-xamarin.sh
@@ -5,7 +5,7 @@ echo " => Creating a temporary directory for codesigndoc ..."
 temp_dir="$(mktemp -d -t codesigndocXXXXXX)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
-version_to_use="2.4.1"
+version_to_use="2.4.4"
 if [ "$1" != "" ] ; then
     version_to_use="$1"
 fi

--- a/_scripts/install_wrap-xcode-uitests.sh
+++ b/_scripts/install_wrap-xcode-uitests.sh
@@ -5,7 +5,7 @@ echo " => Creating a temporary directory for codesigndoc ..."
 temp_dir="$(mktemp -d -t codesigndocXXXXXX)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
-version_to_use="2.4.1"
+version_to_use="2.4.4"
 if [ "$1" != "" ] ; then
     version_to_use="$1"
 fi

--- a/_scripts/install_wrap-xcode.sh
+++ b/_scripts/install_wrap-xcode.sh
@@ -5,7 +5,7 @@ echo " => Creating a temporary directory for codesigndoc ..."
 temp_dir="$(mktemp -d -t codesigndocXXXXXX)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
-version_to_use="2.4.1"
+version_to_use="2.4.4"
 if [ "$1" != "" ] ; then
     version_to_use="$1"
 fi

--- a/_scripts/install_wrap.sh
+++ b/_scripts/install_wrap.sh
@@ -5,7 +5,7 @@ echo " => Creating a temporary directory for codesigndoc ..."
 temp_dir="$(mktemp -d -t codesigndocXXXXXX)"
 codesigndoc_bin_path="${temp_dir}/codesigndoc"
 
-version_to_use="2.4.1"
+version_to_use="2.4.4"
 if [ "$1" != "" ] ; then
     version_to_use="$1"
 fi


### PR DESCRIPTION
Resolves issues with M1 as well as adds additional options for `-sdk` and `-destination` :
-`sdk`: If a value is specified for this flag it'll be passed to xcodebuild as the value of the `-sdk` flag. For more info about the values please see xcodebuild's -sdk flag docs. Example value: `iphoneos`")

-`destination`: The xcodebuild `-destination` option takes as its argument a destination specifier describing the device (or devices) to use as a destination i.e `generic/platform=iOS`.
