### PR TITLE
Fix xcodebuild version parsing on M1 mac

### DIFF
--- a/vendor/github.com/bitrise-io/go-xcode/utility/utility.go
+++ b/vendor/github.com/bitrise-io/go-xcode/utility/utility.go
@@ -2,6 +2,7 @@ package utility
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -44,8 +45,13 @@ func getXcodeVersionFromXcodebuildOutput(outStr string) (models.XcodebuildVersio
 func GetXcodeVersion() (models.XcodebuildVersionModel, error) {
 	cmd := command.New("xcodebuild", "-version")
 	outStr, err := cmd.RunAndReturnTrimmedCombinedOutput()
+
+	// Ignore unrelated warnings on Apple silicon
+	r, _ := regexp.Compile("(objc.+\n)")
+	filtered := r.ReplaceAllString(outStr, "")
+
 	if err != nil {
 		return models.XcodebuildVersionModel{}, fmt.Errorf("xcodebuild -version failed, err: %s, details: %s", err, outStr)
 	}
-	return getXcodeVersionFromXcodebuildOutput(outStr)
+	return getXcodeVersionFromXcodebuildOutput(filtered)
 }


### PR DESCRIPTION
On at least some M1 macs, the output of `xcodebuild -version` to stdout is:
```
objc[95130]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libamsupport.dylib (0x1e358b678) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x103d882c8). One of the two will be used. Which one is undefined.
objc[95130]: Class AMSupportURLSession is implemented in both /usr/lib/libamsupport.dylib (0x1e358b6c8) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x103d88318). One of the two will be used. Which one is undefined.
Xcode 13.2.1
Build version 13C100
```

This causes `codesigndoc scan xcode` to produce the following error:
```
Error: failed to get Xcode (xcodebuild) version, error: failed to parse xcodebuild version output (objc[95130]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libamsupport.dylib (0x1e358b678) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x103fbc2c8). One of the two will be used. Which one is undefined.
objc[95130]: Class AMSupportURLSession is implemented in both /usr/lib/libamsupport.dylib (0x1e358b6c8) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x103fbc318). One of the two will be used. Which one is undefined.
Xcode 13.2.1
Build version 13C100)
```

Added a regex to filter the output.
