### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION ...
-const VERSION = "2.4.4"
+const VERSION = "3.0.0"


### PR DESCRIPTION
This PR bumps `codesigndoc` version to 3.0.0.