### PR TITLE
Fix arm64 build

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -23,7 +23,6 @@ workflows:
             
             export ARCH=arm64
             export GOARCH=arm64
-            export CGO_ENABLED=1
             export CGO_ENABLED=1 # needed for cross-compilation of C code in `osxkeychain` package
             go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,6 +29,7 @@ workflows:
             export GOARCH=amd64
             export OS=Linux
             export GOOS=linux
+            export CGO_ENABLED=0
             go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
 
   update-wrapper-versions:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -18,18 +18,13 @@ workflows:
             export GOARCH=amd64
             export GOOS=darwin
             export OS=Darwin
+            export CGO_ENABLED=1 # needed for cross-compilation of C code in `osxkeychain` package
             go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
             
             export ARCH=arm64
             export GOARCH=arm64
             export CGO_ENABLED=1
-            go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
-            
-            export ARCH=x86_64
-            export GOARCH=amd64
-            export OS=Linux
-            export GOOS=linux
-            export CGO_ENABLED=0
+            export CGO_ENABLED=1 # needed for cross-compilation of C code in `osxkeychain` package
             go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
 
   update-wrapper-versions:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -22,6 +22,7 @@ workflows:
             
             export ARCH=arm64
             export GOARCH=arm64
+            export CGO_ENABLED=1
             go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
             
             export ARCH=x86_64

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -8,6 +8,27 @@ workflows:
     - golint:
     - errcheck:
     - go-test:
+    - script:
+        title: Test cgo config by building all possible binaries
+        inputs:
+        - content: |-
+            set -ex
+            
+            export ARCH=x86_64
+            export GOARCH=amd64
+            export GOOS=darwin
+            export OS=Darwin
+            go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
+            
+            export ARCH=arm64
+            export GOARCH=arm64
+            go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
+            
+            export ARCH=x86_64
+            export GOARCH=amd64
+            export OS=Linux
+            export GOOS=linux
+            go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
 
   update-wrapper-versions:
     steps:

--- a/osxkeychain/osxkeychain.go
+++ b/osxkeychain/osxkeychain.go
@@ -11,8 +11,8 @@ import (
 )
 
 /*
-#cgo arm64 amd64 CFLAGS: -mmacosx-version-min=10.7 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1060
-#cgo arm64 amd64 LDFLAGS: -framework CoreFoundation -framework Security
+#cgo CFLAGS: -mmacosx-version-min=10.7 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1060
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
 #include <stdlib.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>

--- a/osxkeychain/osxkeychain.go
+++ b/osxkeychain/osxkeychain.go
@@ -11,8 +11,8 @@ import (
 )
 
 /*
-#cgo CFLAGS: -mmacosx-version-min=10.7 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1060
-#cgo LDFLAGS: -framework CoreFoundation -framework Security
+#cgo arm64 amd64 CFLAGS: -mmacosx-version-min=10.7 -D__MAC_OS_X_VERSION_MAX_ALLOWED=1060
+#cgo arm64 amd64 LDFLAGS: -framework CoreFoundation -framework Security
 #include <stdlib.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>


### PR DESCRIPTION
Wanted to fix the broken `arm64` cross-compilation, but ended up only adding a test to make sure cross-compilation works. The real fix is added to `Tooling Control Center`'s release workflow instead, because it needs to be fixed in the workflow, not in code.

The reason cross-compilation fails is that `codesigndoc` contains C code in the `osxkeychain` package, and in this case cross-compilation is not working automatically, we need to add `CGO_ENALBED=1` to explicitly enable this behavior.