### PR TITLE
Use Goreleaser to publish releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ codesigndoc_exports
 .gows.user.yml
 .DS_Store
 .idea/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,58 @@
+before:
+  hooks:
+  - go mod tidy
+
+builds:
+- env:
+  # Required for the osxkeychain package (calls into C code)
+  - CGO_ENABLED=1
+  goos:
+  - darwin
+  goarch:
+  - amd64
+  - arm64
+
+archives:
+# GitHub release should contain the raw binaries (no zip or tar.gz)
+- format: binary
+  # Name format should match the curl install script
+  name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+  replacements:
+    darwin: Darwin
+    amd64: x86_64
+
+release:
+  github:
+    owner: bitrise-io
+    name: codesigndoc
+  draft: true
+  mode: replace
+  footer: |
+    ### Install or upgrade
+
+    To install this version, run the following command (in a bash shell):
+    
+      ```bash
+      curl -fL https://github.com/bitrise-io/{{ .ProjectName }}/releases/download/{{ .Tag }}/{{ .ProjectName }}-"$(uname -s)"-"$(uname -m)" > /usr/local/bin/{{ .ProjectName }}
+      ```
+    ℹ️ M1 machine: Please note by default `/usr/local/bin` does not exist on M1 machines and isn't encouraged by the community over `/opt/bin`. Use a custom folder path or use your own `bin` folder path. i.e `/opt/bin`
+    
+    Then:
+    
+      ```
+      chmod +x /usr/local/bin/{{ .ProjectName }}
+      ```
+    
+      That's all, you're ready to call `{{ .ProjectName }}`!
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  # Run `goreleaser release --snapshot` locally to create binaries without publishing and checks
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,37 +1,40 @@
-format_version: 7
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
-  test:  
+  test:
     steps:
-    - go-list:
-    - golint:
-    - errcheck:
-    - go-test:
-    - script:
-        title: Test cgo config by building all possible binaries
-        inputs:
-        - content: |-
-            set -ex
-            
-            export ARCH=x86_64
-            export GOARCH=amd64
-            export GOOS=darwin
-            export OS=Darwin
-            export CGO_ENABLED=1 # needed for cross-compilation of C code in `osxkeychain` package
-            go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
-            
-            export ARCH=arm64
-            export GOARCH=arm64
-            export CGO_ENABLED=1 # needed for cross-compilation of C code in `osxkeychain` package
-            go build -o "$BITRISE_DEPLOY_DIR/codesigndoc-$OS-$ARCH"
+    - go-list: { }
+    - golint: { }
+    - errcheck: { }
+    - go-test: { }
 
-  update-wrapper-versions:
+  create-release:
+    description: Creates Darwin binaries, then publishes a GitHub release
+    envs:
+    - GITHUB_TOKEN: $GIT_BOT_USER_ACCESS_TOKEN # Goreleaser expects this env var
     steps:
     - script:
-        title: Creating release install_wrap
+        title: Goreleaser (create binaries + publish to GH)
+        deps:
+          brew:
+          - name: goreleaser
         inputs:
-        - content: |-
-            cd ./_scripts
-            go run update_wrapper_versions.go
-            cd -
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+            goreleaser release
+
+  test-binary-build:
+    description: Tests the release build process by creating a snapshot release (without publishing)
+    steps:
+    - script:
+        title: Goreleaser (create snapshot binaries)
+        deps:
+          brew:
+          - name: goreleaser
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+            set -ex
+            goreleaser release --snapshot --rm-dist

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -25,6 +25,17 @@ workflows:
             set -ex
             goreleaser release
 
+  update-wrapper-versions:
+    description: Updates the versions in scripts (see README)
+    steps:
+    - script:
+        title: Creating release install_wrap
+        inputs:
+        - content: |-
+            cd ./_scripts
+            go run update_wrapper_versions.go
+            cd -
+
   test-binary-build:
     description: Tests the release build process by creating a snapshot release (without publishing)
     steps:


### PR DESCRIPTION
### Context

Use [Goreleaser](https://goreleaser.com/) for building the release binaries of codesigndoc. The current bash scripts and workflows that build and publish the binaries to GitHub are error prone and the entire release workflow is defined at multiple places (`bitrise.yml` in the repo, Bitrise project of the CLI, the `tooling-control-center`).

This PR simplifies the workflow and defines the entire process as source files in the repo (so that we can keep track of changes)

### Changes

- Create Goreleaser config file as `.goreleaser.yml`
- Build arm64 and amd64 binaries for macOS (just like before)
- Use Goreleaser to create the changelog and publish a GitHub release. This was previously defined in the `tooling-control-center` workflow
- Test the release process in the PR validation workflow by creating a snapshot release (without publishing)